### PR TITLE
fix(cars): Trim vehicle plate on qbcore to avoid spacing in custom plates

### DIFF
--- a/frameworks/qbcore/server.lua
+++ b/frameworks/qbcore/server.lua
@@ -487,6 +487,8 @@ function Utils.Framework.generatePlate(plate_format)
 	if isDuplicate == 1 then
 		generatedPlate = Utils.Framework.generatePlate(plateFormat)
 	end
+	-- Trim any leading/trailing spaces before returning
+	generatedPlate = generatedPlate:match('^%s*(.-)%s*$')
 	return generatedPlate
 end
 


### PR DESCRIPTION
I had the issue that some plates that were custom from my players where stored into the database like "  plate  " because they were shorter than 8. 

This is the fix for it.